### PR TITLE
Added instructions to get dependencies via homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ ledit has some dependencies you will need to build it:
 * GLFW3: used to create the window.
 * freetype2: required for font rendering.
 
+(Homebrew) To get the required dependencies, do:
+```
+brew install glfw freetype2 glm
+```
+
 You will also need CMake.
 
 To build the binary on mac:


### PR DESCRIPTION
During compiling, i was missing the required dependencies and there was no information on what specific dependencies i need to grab.

This should make the instructions more understandable.