### PR TITLE
Include sys/wait.h for missing symbol "wait" in providers.h

### DIFF
--- a/src/providers.h
+++ b/src/providers.h
@@ -8,6 +8,7 @@
 #ifndef _WIN32
 #include <signal.h>
 #include <unistd.h>
+#include <sys/wait.h>
 #endif
 #ifdef __linux__
 #include <fontconfig/fontconfig.h>


### PR DESCRIPTION
In wait(3p), it is explained that wait is in sys/wait.h for posix systems,
hence we need to include this for portability