### PR TITLE
Check if the window handle is null, before trying to set the window title

### DIFF
--- a/src/state.h
+++ b/src/state.h
@@ -252,7 +252,9 @@ class State {
           std::string fName = split[split.size() -1];
           fileName = create(fName);
           std::string window_name = "ledit: " + path;
-          glfwSetWindowTitle(window, window_name.c_str());
+          if(window != NULL) {
+            glfwSetWindowTitle(window, window_name.c_str());
+          }
           tryEnableHighlighting();
         }
         } else {
@@ -461,7 +463,9 @@ class State {
       renderCoords();
     }
     std::string window_name = "ledit: " + path;
-    glfwSetWindowTitle(window, window_name.c_str());
+    if(window!=NULL) {
+      glfwSetWindowTitle(window, window_name.c_str());
+    }
 
   }
   void addCursor(std::string path) {


### PR DESCRIPTION
This fixes this backtrace I got:

```
0  0x00007f1458303871 in raise () from /lib64/libc.so.6
1  0x00007f14582ed538 in abort () from /lib64/libc.so.6
2  0x00007f14582ed421 in ?? () from /lib64/libc.so.6
3  0x00007f14582fc062 in __assert_fail () from /lib64/libc.so.6
4  0x00005633a7bd1af5 in glfwSetWindowTitle (handle=0x0, title=0x7fff8da5ba30 "ledit: ")
   at ledit/third-party/glfw/src/window.c:497
5  0x00005633a7b86948 in State::activateCursor (this=0x7fff8da5c260, cursorIndex=0)
   at ledit/src/state.h:464
6  0x00005633a7b86f49 in State::addCursor (this=0x7fff8da5c260, path="")
   at ledit/src/state.h:477
7  0x00005633a7b87187 in State::State (this=0x7fff8da5c260, w=1280, h=720, path="",
   fontSize=30) at ledit/src/state.h:485
8  0x00005633a7b5c790 in main (argc=1, argv=0x7fff8da5c838)
   at ledit/src/main.cc:269

```

I.e. the State constructor adds a cursor before glfw is even initialized...