### PR TITLE
perf: cache boolean.

### DIFF
--- a/src/cursor.h
+++ b/src/cursor.h
@@ -169,6 +169,8 @@ class Cursor {
     }
     x = targetX;
     y = targetY;
+    selection.diffX(x);
+    selection.diffY(y);
 
   }
   void reset() {
@@ -1039,7 +1041,7 @@ void appendWithLines(std::u16string content) {
     edited = false;
     return true;
   }
-  std::vector<std::pair<int, std::u16string>>* getContent(FontAtlas* atlas, float maxWidth) {
+  std::vector<std::pair<int, std::u16string>>* getContent(FontAtlas* atlas, float maxWidth, bool onlyCalculate) {
     prepare.clear();
     int end = skip + maxLines;
     if(end >= lines.size()) {
@@ -1056,6 +1058,12 @@ void appendWithLines(std::u16string content) {
       skip--;
       end--;
     }
+    /*
+      Here we only care about the frame to render being adjusted for the linenumbers,
+      content itself relies on maxWidth being accurate!
+    */
+    if(onlyCalculate)
+      return nullptr;
     int maxSupport = 0;
     for(size_t i = skip; i < end; i++) {
       auto s = lines[i];

--- a/src/main.cc
+++ b/src/main.cc
@@ -3,6 +3,8 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <thread>
+#include <chrono>
 #ifndef __APPLE__
 #include <algorithm>
 #endif
@@ -344,9 +346,14 @@ int main(int argc, char** argv) {
     while (!glfwWindowShouldClose(window))
     {
       if(state.cacheValid) {
+        if(state.focused)
+          std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        else 
+          std::this_thread::sleep_for(std::chrono::milliseconds(100));
         glfwPollEvents();
         continue;
       }
+      std::cout << "render logic running\n";
       bool changed = false;
       if(HEIGHT != state.HEIGHT || WIDTH != state.WIDTH || fontSize != state.fontSize) {
          WIDTH = state.WIDTH;

--- a/src/main.cc
+++ b/src/main.cc
@@ -353,7 +353,6 @@ int main(int argc, char** argv) {
         glfwPollEvents();
         continue;
       }
-      std::cout << "render logic running\n";
       bool changed = false;
       if(HEIGHT != state.HEIGHT || WIDTH != state.WIDTH || fontSize != state.fontSize) {
          WIDTH = state.WIDTH;

--- a/src/main.cc
+++ b/src/main.cc
@@ -3,8 +3,6 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <thread>
-#include <chrono>
 #ifndef __APPLE__
 #include <algorithm>
 #endif
@@ -346,11 +344,7 @@ int main(int argc, char** argv) {
     while (!glfwWindowShouldClose(window))
     {
       if(state.cacheValid) {
-        if(state.focused)
-          std::this_thread::sleep_for(std::chrono::milliseconds(1));
-        else 
-          std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        glfwPollEvents();
+        glfwWaitEvents();
         continue;
       }
       bool changed = false;
@@ -700,7 +694,7 @@ int main(int argc, char** argv) {
 
       glfwSwapBuffers(window);
       state.cacheValid = true;
-      glfwPollEvents();
+      glfwWaitEvents();
     }
     glfwTerminate();
   return 0;

--- a/src/shaders.h
+++ b/src/shaders.h
@@ -97,17 +97,10 @@ const std::string cursor_shader_frag = R"(
 
 #version 330 core
 
-#define PERIOD 0.8
-#define BLINK_THRESHOLD 0.5
 
-uniform float time;
-uniform float last_stroke;
 out vec4 diffuseColor;
 void main() {
-    float t = time - last_stroke;
-    float threshold = float(t < BLINK_THRESHOLD);
-    float blink = mod(floor(t / PERIOD), 2);
-    diffuseColor = vec4(0.8,0.8,1.0,1.0) *  min(threshold + blink, 1.0);
+    diffuseColor = vec4(0.8,0.8,1.0,1.0);
 }
 
 )";

--- a/src/state.h
+++ b/src/state.h
@@ -25,6 +25,7 @@ class State {
   GLuint vao, vbo;
   bool focused = true;
   bool exitFlag = false;
+  bool cacheValid = false;
   GLuint sel_vao, sel_vbo;
   GLuint highlight_vao, highlight_vbo;
   Cursor* cursor;
@@ -43,13 +44,17 @@ class State {
   std::u16string status;
   std::u16string miniBuf;
   std::u16string dummyBuf;
-  double lastStroke;
   bool showLineNumbers = true;
   bool highlightLine = true;
   int mode = 0;
   int round = 0;
   int fontSize;
   State() {}
+
+  void invalidateCache() {
+    cacheValid = false;
+  }
+
   CursorEntry* hasEditedBuffer() {
     for(CursorEntry* cur : cursors) {
       if(cur->cursor.edited)
@@ -479,7 +484,6 @@ class State {
   State(float w, float h, int fontSize) {
 
     this->fontSize = fontSize;
-    lastStroke = 0;
     WIDTH = w;
     HEIGHT = h;
   }


### PR DESCRIPTION
Thie does two things in main:

It stops the entire logic in the render loop when not needed to reduce idle cpu usage, i.e window events since ledit is entirely user interaction based, all logic is reaction based in that sense.
A special thanks here to @kennylevinsen who reported this and proposed the solution.

The second thing is a fix for the windows operating system where resizing broke scaling and in turn also breaking the mouse cursor positioning feature.

As a side effect this currently also removes the cursor blink but i do not think this is needed anyway,
if not open a issue il re add it.